### PR TITLE
Removed mqtt npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/snipsco/ble-relay-js#readme",
   "dependencies": {
-    "mqtt": "^2.9.1",
     "bleno": "^0.4.2",
     "simple-datagram-protocol": "^0.2.0"
   },


### PR DESCRIPTION
MQTT references were removed, so package is not required.